### PR TITLE
Old versions + better logger + less typos (i guess)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
 # Preloading Tricks
 
-A mod that add hook before setup mod. Mainly using for [ModSets](https://github.com/SettingDust/ModSets)  
-It's only depends on the loader version. May working on lower version but need test and feedback
-  * Fabric 0.14
-  * Quilt 0.20
-  * Forge 45
+A mod that adds a hook before setting up the main mod. Mainly used for [ModSets](https://github.com/SettingDust/ModSets) and [AutoModpack](https://github.com/Skidamek/AutoModpack).  
+It only depends on the loader version. It may work on lower versions than these, but that needs testing and feedback.
+* Fabric 0.14
+* Quilt 0.20
+* Forge 45
 
 ## Callbacks
 
 ### Setup Mod
 
-https://github.com/SettingDust/preloading-tricks/blob/main/preloading-callbacks/src/main/java/settingdust/preloadingtricks/SetupModCallback.java
-The callback is using java [`ServiceLoader`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html)  
-It will be invoked at just before setup mods.   
-  
-Using `SetupModService` implementations for platforms to control the mod loading.  
+The callback is using Java's [`ServiceLoader`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html) feature.  
+It will be invoked just before setting up the mods.
 
-  * Forge: https://github.com/SettingDust/preloading-tricks/blob/main/fml-45/src/main/java/settingdust/preloadingtricks/forge/ForgeLanguageProviderCallback.java#L98
-  * Fabric: https://github.com/SettingDust/preloading-tricks/blob/main/fabric-loader-0.14/src/main/java/settingdust/preloadingtricks/fabric/FabricLanguageProviderCallback.java#L64
-  * Quilt: https://github.com/SettingDust/preloading-tricks/blob/main/quilt-loader-0.20/src/main/java/settingdust/preloadingtricks/quilt/QuiltLanguageProviderCallback.java#L62
-  
-With the callback you can control the mod loading.   
-Notice it's not recommend to add mod since it can't load mod from file or classpath. Using `IModLocator` is officially supported by forge.
+Using `SetupModService` implementations for platforms to control the mod loading.
+
+* Forge: [link](https://github.com/SettingDust/preloading-tricks/blob/main/fml-45/src/main/java/settingdust/preloadingtricks/forge/ForgeLanguageProviderCallback.java#L98)
+* Fabric: [link](https://github.com/SettingDust/preloading-tricks/blob/main/fabric-loader-0.14/src/main/java/settingdust/preloadingtricks/fabric/FabricLanguageProviderCallback.java#L64)
+* Quilt: [link](https://github.com/SettingDust/preloading-tricks/blob/main/quilt-loader-0.20/src/main/java/settingdust/preloadingtricks/quilt/QuiltLanguageProviderCallback.java#L62)
+
+With the callback, you can control the mod loading.   
+Notice: It's not recommended to add mods since it can't load mods from a file or classpath. Using `IModLocator` is officially supported by Forge.
 
 ### Language Provider
 
-The callback is using java [`ServiceLoader`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html).    
-It's a bit earlier than setup mod.    
+The callback is using Java's [`ServiceLoader`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html).    
+It's invoked much earlier than setting up the main mod.    

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,28 +117,28 @@ tasks {
     }
 }
 
-modrinth {
-    token.set(env.MODRINTH_TOKEN.value) // This is the default. Remember to have the MODRINTH_TOKEN environment variable set or else this will fail, or set it to whatever you want - just make sure it stays private!
-    projectId.set("preloading-tricks") // This can be the project ID or the slug. Either will work!
-    syncBodyFrom.set(rootProject.file("README.md").readText())
-    versionType.set("release") // This is the default -- can also be `beta` or `alpha`
-    uploadFile.set(tasks.shadowJar) // With Loom, this MUST be set to `remapJar` instead of `jar`!
-    changelog.set(rootProject.file("CHANGELOG.md").readText())
-    gameVersions.addAll(
-        "1.19",
-        "1.19.1",
-        "1.19.2",
-        "1.19.3",
-        "1.19.4",
-        "1.20",
-        "1.20.1",
-    ) // Must be an array, even with only one version
-    loaders.addAll(
-        "fabric",
-        "quilt",
-        "forge"
-    ) // Must also be an array - no need to specify this if you're using Loom or ForgeGradle
-}
+//modrinth {
+//    token.set(env.MODRINTH_TOKEN.value) // This is the default. Remember to have the MODRINTH_TOKEN environment variable set or else this will fail, or set it to whatever you want - just make sure it stays private!
+//    projectId.set("preloading-tricks") // This can be the project ID or the slug. Either will work!
+//    syncBodyFrom.set(rootProject.file("README.md").readText())
+//    versionType.set("release") // This is the default -- can also be `beta` or `alpha`
+//    uploadFile.set(tasks.shadowJar) // With Loom, this MUST be set to `remapJar` instead of `jar`!
+//    changelog.set(rootProject.file("CHANGELOG.md").readText())
+//    gameVersions.addAll(
+//        "1.19",
+//        "1.19.1",
+//        "1.19.2",
+//        "1.19.3",
+//        "1.19.4",
+//        "1.20",
+//        "1.20.1",
+//    ) // Must be an array, even with only one version
+//    loaders.addAll(
+//        "fabric",
+//        "quilt",
+//        "forge"
+//    ) // Must also be an array - no need to specify this if you're using Loom or ForgeGradle
+//}
 
 publishing {
     publications {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,28 +117,28 @@ tasks {
     }
 }
 
-//modrinth {
-//    token.set(env.MODRINTH_TOKEN.value) // This is the default. Remember to have the MODRINTH_TOKEN environment variable set or else this will fail, or set it to whatever you want - just make sure it stays private!
-//    projectId.set("preloading-tricks") // This can be the project ID or the slug. Either will work!
-//    syncBodyFrom.set(rootProject.file("README.md").readText())
-//    versionType.set("release") // This is the default -- can also be `beta` or `alpha`
-//    uploadFile.set(tasks.shadowJar) // With Loom, this MUST be set to `remapJar` instead of `jar`!
-//    changelog.set(rootProject.file("CHANGELOG.md").readText())
-//    gameVersions.addAll(
-//        "1.19",
-//        "1.19.1",
-//        "1.19.2",
-//        "1.19.3",
-//        "1.19.4",
-//        "1.20",
-//        "1.20.1",
-//    ) // Must be an array, even with only one version
-//    loaders.addAll(
-//        "fabric",
-//        "quilt",
-//        "forge"
-//    ) // Must also be an array - no need to specify this if you're using Loom or ForgeGradle
-//}
+modrinth {
+    token.set(env.MODRINTH_TOKEN.value) // This is the default. Remember to have the MODRINTH_TOKEN environment variable set or else this will fail, or set it to whatever you want - just make sure it stays private!
+    projectId.set("preloading-tricks") // This can be the project ID or the slug. Either will work!
+    syncBodyFrom.set(rootProject.file("README.md").readText())
+    versionType.set("release") // This is the default -- can also be `beta` or `alpha`
+    uploadFile.set(tasks.shadowJar) // With Loom, this MUST be set to `remapJar` instead of `jar`!
+    changelog.set(rootProject.file("CHANGELOG.md").readText())
+    gameVersions.addAll(
+        "1.19",
+        "1.19.1",
+        "1.19.2",
+        "1.19.3",
+        "1.19.4",
+        "1.20",
+        "1.20.1",
+    ) // Must be an array, even with only one version
+    loaders.addAll(
+        "fabric",
+        "quilt",
+        "forge"
+    ) // Must also be an array - no need to specify this if you're using Loom or ForgeGradle
+}
 
 publishing {
     publications {

--- a/fabric-like-language-adapter/src/main/java/settingdust/preloadingtricks/DummyLanguageAdapter.java
+++ b/fabric-like-language-adapter/src/main/java/settingdust/preloadingtricks/DummyLanguageAdapter.java
@@ -2,7 +2,7 @@ package settingdust.preloadingtricks;
 
 import net.fabricmc.loader.api.LanguageAdapter;
 import net.fabricmc.loader.api.ModContainer;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
 import settingdust.preloadingtricks.util.ServiceLoaderUtil;
 
 import java.util.ServiceLoader;
@@ -13,7 +13,7 @@ public class DummyLanguageAdapter implements LanguageAdapter {
         ServiceLoaderUtil.loadServices(
                 LanguageProviderCallback.class,
                 ServiceLoader.load(LanguageProviderCallback.class),
-                LoggerFactory.getLogger("PreloadingTricks/LanguageAdapter"));
+                LogManager.getLogger("PreloadingTricks/LanguageAdapter"));
     }
 
     @Override

--- a/fabric-loader-0.14/src/main/java/settingdust/preloadingtricks/fabric/FabricLanguageProviderCallback.java
+++ b/fabric-loader-0.14/src/main/java/settingdust/preloadingtricks/fabric/FabricLanguageProviderCallback.java
@@ -2,7 +2,7 @@ package settingdust.preloadingtricks.fabric;
 
 import net.fabricmc.loader.impl.FabricLoaderImpl;
 import net.fabricmc.loader.impl.ModContainerImpl;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
 import settingdust.preloadingtricks.LanguageProviderCallback;
 import settingdust.preloadingtricks.SetupModCallback;
 import settingdust.preloadingtricks.SetupModService;
@@ -42,7 +42,7 @@ public class FabricLanguageProviderCallback implements LanguageProviderCallback 
         ServiceLoaderUtil.loadServices(
                 SetupModCallback.class,
                 ServiceLoader.load(SetupModCallback.class),
-                LoggerFactory.getLogger("PreloadingTricks/ModSetup"));
+                LogManager.getLogger("PreloadingTricks/ModSetup"));
     }
 
     private class ModsListProxy implements InvocationHandler {

--- a/fml-45/src/main/java/settingdust/preloadingtricks/forge/ForgeLanguageProviderCallback.java
+++ b/fml-45/src/main/java/settingdust/preloadingtricks/forge/ForgeLanguageProviderCallback.java
@@ -6,7 +6,7 @@ import net.minecraftforge.fml.loading.moddiscovery.BackgroundScanHandler;
 import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 import net.minecraftforge.fml.loading.moddiscovery.ModValidator;
 import net.minecraftforge.forgespi.locating.IModFile;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
 import settingdust.preloadingtricks.LanguageProviderCallback;
 import settingdust.preloadingtricks.SetupModCallback;
 import settingdust.preloadingtricks.SetupModService;
@@ -47,7 +47,7 @@ public class ForgeLanguageProviderCallback implements LanguageProviderCallback {
         ServiceLoaderUtil.loadServices(
                 SetupModCallback.class,
                 ServiceLoader.load(SetupModCallback.class, SetupModCallback.class.getClassLoader()),
-                LoggerFactory.getLogger("PreloadingTricks/ModSetup"));
+                LogManager.getLogger("PreloadingTricks/ModSetup"));
     }
 
     private class DummyModValidator extends ModValidator {

--- a/forge-language-provider/src/main/java/settingdust/preloadingtricks/forge/language/DummyLanguageProvider.java
+++ b/forge-language-provider/src/main/java/settingdust/preloadingtricks/forge/language/DummyLanguageProvider.java
@@ -3,7 +3,7 @@ package settingdust.preloadingtricks.forge.language;
 import net.minecraftforge.forgespi.language.ILifecycleEvent;
 import net.minecraftforge.forgespi.language.IModLanguageProvider;
 import net.minecraftforge.forgespi.language.ModFileScanData;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
 import settingdust.preloadingtricks.LanguageProviderCallback;
 import settingdust.preloadingtricks.util.ServiceLoaderUtil;
 
@@ -17,7 +17,7 @@ public class DummyLanguageProvider implements IModLanguageProvider {
         ServiceLoaderUtil.loadServices(
                 LanguageProviderCallback.class,
                 ServiceLoader.load(LanguageProviderCallback.class, DummyLanguageProvider.class.getClassLoader()),
-                LoggerFactory.getLogger("PreloadingTricks/LanguageProvider"));
+                LogManager.getLogger("PreloadingTricks/LanguageProvider"));
     }
 
     public DummyLanguageProvider() {}

--- a/preloading-callbacks/build.gradle.kts
+++ b/preloading-callbacks/build.gradle.kts
@@ -11,5 +11,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.1")
+    implementation("org.apache.logging.log4j:log4j-api:2.20.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.20.0")
 }

--- a/preloading-callbacks/src/main/java/settingdust/preloadingtricks/util/ServiceLoaderUtil.java
+++ b/preloading-callbacks/src/main/java/settingdust/preloadingtricks/util/ServiceLoaderUtil.java
@@ -35,8 +35,8 @@ public class ServiceLoaderUtil {
             } catch (Throwable t) {
 
                 if (!providerName.startsWith("settingdust.preloadingtricks.")) {
-                    logger.debug("Loading " + provider.type().getName() + " failed.");
-                    t.printStackTrace();
+                    logger.error("Loading " + provider.type().getName() + " failed.");
+                    logger.debug(t)
                 }
             }
 

--- a/preloading-callbacks/src/main/java/settingdust/preloadingtricks/util/ServiceLoaderUtil.java
+++ b/preloading-callbacks/src/main/java/settingdust/preloadingtricks/util/ServiceLoaderUtil.java
@@ -1,10 +1,11 @@
 package settingdust.preloadingtricks.util;
 
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ServiceLoader;
 
 public class ServiceLoaderUtil {
+
     public static <T> void loadServices(Class<T> clazz, ServiceLoader<T> serviceLoader, Logger logger) {
         final var iterator = serviceLoader.stream().iterator();
         var hasNext = false;
@@ -22,15 +23,21 @@ public class ServiceLoaderUtil {
         } while (!hasNext);
         while (hasNext) {
             final var provider = iterator.next();
+
+            String providerName = provider.type().getName();
+
+            if (!providerName.startsWith("settingdust.preloadingtricks.")) {
+                logger.info("Preloading-tricks is loading " + provider.type().getName());
+            }
+
             try {
-                logger.info("Loading " + provider.type().getName());
                 provider.get();
             } catch (Throwable t) {
-                logger.error(
-                        "Loading {} failed. Stacktrace is in DEBUG level. {}",
-                        provider.type().getName(),
-                        t.getMessage());
-                logger.debug("Loading " + provider.type().getName() + " failed.", t);
+
+                if (!providerName.startsWith("settingdust.preloadingtricks.")) {
+                    logger.debug("Loading " + provider.type().getName() + " failed.");
+                    t.printStackTrace();
+                }
             }
 
             try {

--- a/quilt-loader-0.20/src/main/java/settingdust/preloadingtricks/quilt/QuiltLanguageProviderCallback.java
+++ b/quilt-loader-0.20/src/main/java/settingdust/preloadingtricks/quilt/QuiltLanguageProviderCallback.java
@@ -1,8 +1,8 @@
 package settingdust.preloadingtricks.quilt;
 
+import org.apache.logging.log4j.LogManager;
 import org.quiltmc.loader.api.plugin.ModContainerExt;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
-import org.slf4j.LoggerFactory;
 import settingdust.preloadingtricks.LanguageProviderCallback;
 import settingdust.preloadingtricks.SetupModCallback;
 import settingdust.preloadingtricks.SetupModService;
@@ -42,7 +42,7 @@ public class QuiltLanguageProviderCallback implements LanguageProviderCallback {
         ServiceLoaderUtil.loadServices(
                 SetupModCallback.class,
                 ServiceLoader.load(SetupModCallback.class),
-                LoggerFactory.getLogger("PreloadingTricks/ModSetup"));
+                LogManager.getLogger("PreloadingTricks/ModSetup"));
     }
 
     private class ModsListProxy implements InvocationHandler {


### PR DESCRIPTION
Changed logger dependency to work with with older versions like 1.16
Fixed some typos, overall made read-me more understandable
Made logger ignore errors from failed loading hooks for different loaders than are used